### PR TITLE
Clean-up, code formatting, few fixes

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,31 +1,36 @@
 # A PDDL Reference Guide
+
 [Go Straight To Contents](#contents) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
+
 ## Introduction
-This reference and guide is here to provide easy access to resources related to the field of AI Planning. AI Planning is difficult to quantify under one roof, due to the variety of ongoing research in the field. 
+
+This reference and guide is here to provide easy access to resources related to the field of AI Planning. AI Planning is difficult to quantify under one roof, due to the variety of ongoing research in the field.
 
 The International Conference on Autonomous Planning and Scheduling has in the course of supporting AI Planning research created a competition for the AI Planning Software (Planners) that have been built to solve AI Planning problems.
 
 This competition, dating from 1998, has defined a general purpose definition language, Planning Domain Definition Language (PDDL), which is designed to be capable of specifying any planning or scheduling problem you could come across.
 
-In reality, PDDL since it's first incarnation in 1998 has had serious modifications to make it capable of handling the complex tasks we expect of modern autonomous planning and scheduling techniques. 
+In reality, PDDL since it's first incarnation in 1998 has had serious modifications to make it capable of handling the complex tasks we expect of modern autonomous planning and scheduling techniques.
 
 For more details on PDDL, Planning, the history, the usage and the research, see the guide.
 
 ## Using This Guide
-This guide splits into three main sections, guide, reference and examples. 
+
+This guide splits into three main sections, guide, reference and examples.
 
 The guide section is here to help the uninitiated get an idea of what planning is and how it can be used. It glazes over technical details where they're complex and difficult to understand. *This is not intended to be a substitute to the copious academic literature written in the subject*.
 
-The reference guide itself splits into two sections, one for the language of planners, PDDL. The other section for the planners which can read and solve PDDL problems. 
+The reference guide itself splits into two sections, one for the language of planners, PDDL. The other section for the planners which can read and solve PDDL problems.
 
 The nature of AI planning and the language means that **not** all features are supported by all planners and not all techniques are used as often as others. The reference here aims to help with that by firstly showing next to each definition an indication of how well supported the feature is and how commonly used it is.
 
->Support: <span style="color:green">Universal</span>, <span style="color:yellow">High</span>, <span style="color:orange">Medium</span>, <span style="color:red">Poor</span>  
+>Support: <span style="color:green">Universal</span>, <span style="color:yellow">High</span>, <span style="color:orange">Medium</span>, <span style="color:red">Poor</span>
 Usage: <span style="color:green">High</span>, <span style="color:yellow">Medium</span>, <span style="color:orange">Low</span>, <span style="color:red">Rare</span>
 
-For planners, this reference will aim to provide indication of what features are supported by what planners. It also provide useful hints and notes about the quirks and specific issues certain planners have in running certain problems. 
+For planners, this reference will aim to provide indication of what features are supported by what planners. It also provide useful hints and notes about the quirks and specific issues certain planners have in running certain problems.
 
 ## Contributions, Corrections and Feedback
+
 [Contributions](./guide/contributing.md) are always welcome!
 
 The best way to provide multiple contributions is to request collaborator access to this repository, either via emailing adam.green@kcl.ac.uk or by filing an issue on [this repo](https://github.com/nergmada/pddl-reference). You can fork this repository to your GitHub, make changes and file a pull request.
@@ -37,6 +42,7 @@ Finally, if you have a planner which you think should be included in this refere
 Any other issues/concerns should be sent to adam.green@kcl.ac.uk and I'll try to get back to you ASAP.
 
 ## Contents
+
 - Guide
     - [What is AI Planning?](./guide/whatisaip.md)
         - [Domain independent Planning](./guide/whatisaip.md#domain%20independent%20planning)
@@ -150,11 +156,11 @@ Any other issues/concerns should be sent to adam.green@kcl.ac.uk and I'll try to
         - [Planning.Domains PDDL Editor](http://editor.planning.domains/)
 - Examples
     - [IPC PDDL Domains](https://github.com/potassco/pddl-instances)
-    - 
+    -
 - FAQ
 
-
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [OPTIC - Optimising Preferences and Time Dependent Costs](https://nms.kcl.ac.uk/planning/software/optic.html)
 - [PDDL+: Modelling Continuous Time Dependent Effects](https://pdfs.semanticscholar.org/d391/59cb5dfcc21aafd3049002d854ec341037a7.pdf) [Fox, M. Long, D.]

--- a/docs/reference/PDDL+/domain.md
+++ b/docs/reference/PDDL+/domain.md
@@ -1,9 +1,9 @@
 # Domain
-[return to homepage](../../readme.md) | [return to PDDL2.1 main page](./main.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
+[return to homepage](../../readme.md) | [return to PDDL+ main page](./main.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
-PDDL+ introduces two new constructs to domains in PDDL, the first is `Processes` and the second is `Events`, both can essentially be thought of as uncontrollable durative actions, and uncontrollable instantaneous actions respectively. 
+PDDL+ introduces two new constructs to domains in PDDL, the first is `Processes` and the second is `Events`, both can essentially be thought of as uncontrollable durative actions, and uncontrollable instantaneous actions respectively.
 
-```
+```LISP
 (define
     (domain ballphysics)
     (:requirements :time :typing)
@@ -19,13 +19,13 @@ PDDL+ introduces two new constructs to domains in PDDL, the first is `Processes`
     )
     (:process FALLING
         :parameters (?b - ball)
-        :precondition (and 
+        :precondition (and
             (not (held ?b))
             (< (velocity ?b) 100)
         )
-        :effect (and 
+        :effect (and
             (increase (velocity ?b) (* #t 9.8))
-            (decrease (distance-to-floor ?b) (* #t (velocity ?b)))    
+            (decrease (distance-to-floor ?b) (* #t (velocity ?b)))
         )
     )
     (:event HIT-GROUND
@@ -45,14 +45,16 @@ PDDL+ introduces two new constructs to domains in PDDL, the first is `Processes`
 ```
 
 ## Contents
+
 - [Requirements](#requirements)
 - [Processes](#processes)
 - [Events](#events)
 
 ## Requirements
+
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `(:requirements <requirement_name>)`
@@ -68,39 +70,40 @@ Only one additional requirement is necessary in order to include **both** proces
 `(:requirements :time)`
 
 ## Processes
+
 [back to contents](#contents)
 
-Support: <span style="color:orange">Medium</span>  
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:orange">Low</span>
 
-
-```
+```LISP
 (:process FALLING
     :parameters (?b - ball)
-    :precondition (and 
+    :precondition (and
         (not (held ?b))
         (< (velocity ?b) 100)
     )
-    :effect (and 
+    :effect (and
         (increase (velocity ?b) (* #t 9.8))
-        (decrease (distance-to-floor ?b) (* #t (velocity ?b)))    
+        (decrease (distance-to-floor ?b) (* #t (velocity ?b)))
     )
 )
 ```
 
-A process is defined in three sections, `:parameters`, `:precondition` and `:effect` which define what a process is acting upon, when a process is acting upon it and what effect that process has when it acts. These directly correspond with the definition of an [action](../PDDL/domain.md#actions) found in PDDL 1.2, but can include the expressivity of numerics as seen in PDDL 2.1. 
+A process is defined in three sections, `:parameters`, `:precondition` and `:effect` which define what a process is acting upon, when a process is acting upon it and what effect that process has when it acts. These directly correspond with the definition of an [action](../PDDL/domain.md#actions) found in PDDL 1.2, but can include the expressivity of numerics as seen in PDDL 2.1.
 
 Confusingly despite bearing similar behaviour to a durative action, a process conditions over it's duration, therefore the precondition can be thought of more like an `over all` condition in PDDL 2.1
 
 `#t` represents the time of the process, it is used to calculate continuous numeric effects, therefore, if about halfway through the process some action might wish to run which conditions on one of the numeric fluents affected by the process, `#t` can be used to calculate the intermediate value of such a numeric fluent.
 
 ## Events
+
 [back to contents](#contents)
 
-Support: <span style="color:orange">Medium</span>  
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:orange">Low</span>
 
-```
+```LISP
 (:event HIT-GROUND
     :parameters (?b - ball)
     :precondition (and
@@ -121,4 +124,5 @@ Note that the distinctive nature of an event is that whilst it can occur more th
 In the case above we see that the condition of hitting the ground is that velocity is greater than 0, and the effect is that velocity is negated, which ensures that - at least for a period - this event cannot run again.
 
 ## Reference
+
 - [PDDL+: Modelling Continuous Time Dependent Effects](https://pdfs.semanticscholar.org/d391/59cb5dfcc21aafd3049002d854ec341037a7.pdf) [Fox, M. Long, D.]

--- a/docs/reference/PDDL+/main.md
+++ b/docs/reference/PDDL+/main.md
@@ -1,4 +1,5 @@
 # PDDL+
+
 [return to homepage](../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 PDDL+ introduced processes and events, to the domain of PDDL. Where previous updates to PDDL had introduced intractable rules such as `Derived Predicates` and `Constraints`, PDDL+ is the first to consider essentially actions which **must** be applied when their preconditions are met.
@@ -7,13 +8,15 @@ PDDL+ introduced processes and events, to the domain of PDDL. Where previous upd
 
 `Events` directly correspond to instantaneous actions, and happen the instant their preconditions are met, usually with the effect of transforming their state such that their precondition is no longer met. `Events` are uncontrollable, and in our ball example, we might consider an event to be the ball hitting the ground. In that instance, the velocity of the ball is negated, and multiplied by some bounce coefficient.
 
-`Processes` and `events` are still very much a challenge for some planners, and support is somewhat patch, with certain planners losing support for earlier features in PDDL in order to support this new feature. Most notably, `Processes` can (and usually do) have a continuous effect in a state, and therefore cause problems if we define a preference such as `preference (always (< (velocity ball) 10))`. 
+`Processes` and `events` are still very much a challenge for some planners, and support is somewhat patch, with certain planners losing support for earlier features in PDDL in order to support this new feature. Most notably, `Processes` can (and usually do) have a continuous effect in a state, and therefore cause problems if we define a preference such as `preference (always (< (velocity ball) 10))`.
 
 ## Contents
+
 - [Domain](./domain.md)
     - [Requirements](./domain.md#requirements)
     - [Processes](./domain.md#processes)
     - [Events](./domain.md#events)
 
 ## Reference
+
 - [PDDL+: Modelling Continuous Time Dependent Effects](https://pdfs.semanticscholar.org/d391/59cb5dfcc21aafd3049002d854ec341037a7.pdf) [Fox, M. Long, D.]

--- a/docs/reference/PDDL/Domain/requirements.md
+++ b/docs/reference/PDDL/Domain/requirements.md
@@ -1,10 +1,12 @@
 # Requirements (PDDL 1.2)
+
 [Return to Homepage](../../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 The following page offers details of requirements defined in PDDL 1.2.
 
 ## STRIPS
-Support: <span style="color:green">Universal</span>  
+
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `(:requirements :strips)`
@@ -20,37 +22,40 @@ Delete:
 `:effect (not (walls-built ?s))`
 
 ## Typing
-Support: <span style="color:green">Universal</span>  
+
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `(:requirements :typing)`
 
 Allows the usage of typing for objects. Typing is similar to classes and sub-classes in Object-Oriented Programming e.g.
 
-```
-(:types 
+```LISP
+(:types
     site material - object
     bricks cables windows - material
 )
 ```
 
 ## Disjunctive Preconditions
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :disjunctive-preconditions)`
 
 Allows the usage of `or` in goals and preconditions e.g.
 
-```
-(or 
-    (walls-built ?s) 
+```LISP
+(or
+    (walls-built ?s)
     (windows-fitted ?s)
 )
 ```
 
 ## Equality
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :equality)`
@@ -60,29 +65,32 @@ Allows the usage of `=` to compare objects. For example if we have two objects a
 `(not (= ?s1 ?s2))`
 
 ## Existential Preconditions
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :existential-preconditions)`
 
 Allows for the use of `exists` in goals and preconditions. Exists is essentially an additional parameter which we don't need apart from a subset of the conditions for example.
 
-```
+```LISP
 (exists (?c - crane)
     (crane-is-free ?c)
 )
 ```
+
 Typically, exists is not used in favour of just adding an additional argument to the action parameters.
 
 ## Universal Preconditions
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :universal-preconditions)`
 
 Allows for the use of `forall` in goals and preconditions. Universal is essentially the counter-part to the `exists` statement, providing for a condition that is true across all objects of a type, or just all objects.
 
-```
+```LISP
 (forall (?c - crane)
     (crane-is-free ?c)
 )
@@ -91,7 +99,8 @@ Allows for the use of `forall` in goals and preconditions. Universal is essentia
 Conditions that all the cranes in the problem are free.
 
 ## Quantified Preconditions
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :quantified-preconditions)`
@@ -101,16 +110,17 @@ Short hand way of expressing both universal and existential preconditions. It is
 `(:requirements :existential-preconditions :universal-preconditions)`
 
 ## Conditional Effects
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :conditional-effects)`
 
 Allows for the usage of `when` in expressing action effects. Essentially saying if something is true, then apply this effect too.
 
-```
+```LISP
 (when
-    ;Antecedent 
+    ;Antecedent
     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
     ;Consequence
     (and (person-is-happy ?p))
@@ -120,41 +130,45 @@ Allows for the usage of `when` in expressing action effects. Essentially saying 
 Here we express that when a person has a hot chocolate with marshmallows in, there is additional effect that the person is happy, which might not otherwise be true had we given them a different beverage or indeed a hot chocolate without marshmallows.
 
 ## Action Expansions
-Support: <span style="color:red">None</span>  
+
+Support: <span style="color:red">None</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :action-expansions)`
 
-Allows for usage of action expansions. This allows for the definition of variant condition and effects of actions. Essentially, we could define a `MOVE` action to describe movement of say a person, but include different expansions to describe movement by plane, train, car or foot. 
+Allows for usage of action expansions. This allows for the definition of variant condition and effects of actions. Essentially, we could define a `MOVE` action to describe movement of say a person, but include different expansions to describe movement by plane, train, car or foot.
 
 This has be rendered redundant as we would instead just express multiple actions such as `MOVE-BY-PLANE` and `MOVE-BY-TRAIN`.
 
 ## Foreach Expansions
-Support: <span style="color:red">None</span>  
+
+Support: <span style="color:red">None</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :foreach-expansions)`
 
 Allows for usage of `foreach` in action expansions, essentially allowing the application of effects across a type of object or across all objects.
 
-This requirement implies the existence of the `:action-expansions` requirement and therefore is equivalent to 
+This requirement implies the existence of the `:action-expansions` requirement and therefore is equivalent to
 
 `(:requirements :action-expansions :foreach-expansions)`
 
 ## DAG Expansions
-Support: <span style="color:red">None</span>  
+
+Support: <span style="color:red">None</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :dag-expansions)`
 
 Allows the expansions described in Action Expansions to labelled so that you can distinguish between which sub-action was chosen by the planner. For example if we defined a `move` action which makes use of different modes of transport we might want to know exactly what mode was used by labelling.
 
-This requirement implies the existence of the `:action-expansions` requirement and therefore is equivalent to 
+This requirement implies the existence of the `:action-expansions` requirement and therefore is equivalent to
 
 `(:requirements :action-expansions :dag-expansions)`
 
 ## Domain Axioms
-Support: <span style="color:yellow">Medium</span>  
+
+Support: <span style="color:yellow">Medium</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :domain-axioms)`
@@ -162,17 +176,19 @@ Usage: <span style="color:orange">Low</span>
 Allows the use of axioms. Axioms are essentially predicates that are implied by other predicates. See the section on Axioms in the domain reference for PDDL 1.2
 
 ## Subgoals Through Axioms
-Support: <span style="color:red">Poor</span>  
+
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :subgoals-through-axioms)`
 
-Subgoals through axioms is a way of creating subgoals by showing that an axiom is a subset of the goal. This has become fairly redundant as this is something a planner could extract through domain preprocessing. 
+Subgoals through axioms is a way of creating subgoals by showing that an axiom is a subset of the goal. This has become fairly redundant as this is something a planner could extract through domain preprocessing.
 
 A user should not have to tell a planner the techniques it should use to solve a problem and so subgoals through axioms runs counter to that in some way.
 
 ## Safety Constraints
-Support: <span style="color:red">Poor</span>  
+
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :safety-constraints)`
@@ -180,7 +196,8 @@ Usage: <span style="color:red">Rare</span>
 A safety constraint is a predicate which must be true by the end of the plan in order for the plan to be considered valid. How this varies from a goal state is not really clear.
 
 ## Expression Evaluation
-Support: <span style="color:red">Poor</span>  
+
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :expression-evaluation)`
@@ -191,24 +208,26 @@ Allows the usage of `eval` in axioms, in which two predicates are compared to on
 
 Evaluates to false, if we assume that `im-not-true` is false and `im-true` is true.
 
-This requirement implies the existence of the `:domain-axioms` requirement and therefore is equivalent to 
+This requirement implies the existence of the `:domain-axioms` requirement and therefore is equivalent to
 
 `(:requirements :domain-axioms :expression-evaluation)`
 
 ## Fluents
-Support: <span style="color:pink">Meaning Has Changed</span>  
+
+Support: <span style="color:pink">Meaning Has Changed</span>
 Usage: <span style="color:red">Rare (in this context)</span>
 
 `(:requirements :fluents)`
 
-Allows the usage of `(fluents t)`, fluent support in PDDL1.2 is different to how later versions of PDDL model numeric values. 
+Allows the usage of `(fluents t)`, fluent support in PDDL1.2 is different to how later versions of PDDL model numeric values.
 
-This requirement implies the existence of the `:expression-evaluation` requirement and therefore is equivalent to 
+This requirement implies the existence of the `:expression-evaluation` requirement and therefore is equivalent to
 
 `(:requirements :expression-evaluation :fluents)`
 
 ## Open World
-Support: <span style="color:red">Poor</span>  
+
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :open-world)`
@@ -218,19 +237,21 @@ In planning all unknown values are assumed to be false. That is to say that if w
 This is rarely supported in more modern planners and often is a flag in the planner execution and not a requirement in the domain.
 
 ## True Negation
-Support: <span style="color:red">Poor</span>  
+
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :true-negation)`
 
-Don't treat negation as failure, treat it how it is in first order logic. 
+Don't treat negation as failure, treat it how it is in first order logic.
 
-This requirement implies the existence of the `:open-world` requirement and therefore is equivalent to 
+This requirement implies the existence of the `:open-world` requirement and therefore is equivalent to
 
 `(:requirements :open-world :true-negation)`
 
 ## ADL
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :adl)`
@@ -245,7 +266,8 @@ ADL is a super requirement which adds the following requirements
 - `:condition-effects`
 
 ## UCPOP
-Support: <span style="color:red">Poor</span>  
+
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:requirements :ucpop)`
@@ -257,5 +279,6 @@ UCPOP is a super requirement which adds the following requirements
 - `:safety-constraints`
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [OPTIC - Optimising Preferences and Time Dependent Costs](https://nms.kcl.ac.uk/planning/software/optic.html)

--- a/docs/reference/PDDL/domain.md
+++ b/docs/reference/PDDL/domain.md
@@ -8,7 +8,7 @@ A domain file in PDDL 1.2 defines the "universal" aspects of a problem. Essentia
     (domain construction)
     (:extends building)
     (:requirements :strips :typing)
-    (:types 
+    (:types
         site material - object
         bricks cables windows - material
     )
@@ -28,9 +28,9 @@ A domain file in PDDL 1.2 defines the "universal" aspects of a problem. Essentia
 
     (:timeless (foundations-set mainsite))
 
-    ;(:safety 
-        (forall 
-            (?s - site) (walls-built ?s)))
+    ;(:safety
+        ;(forall
+        ;    (?s - site) (walls-built ?s)))
         ;deprecated
 
     (:action BUILD-WALL
@@ -48,7 +48,7 @@ A domain file in PDDL 1.2 defines the "universal" aspects of a problem. Essentia
         ; :expansion ;deprecated
     )
 
-    ;(:axiom
+    (:axiom
         :vars (?s - site)
         :context (and
             (walls-built ?s)
@@ -61,7 +61,9 @@ A domain file in PDDL 1.2 defines the "universal" aspects of a problem. Essentia
     ;Actions omitted for brevity
 )
 ```
+
 ## Contents
+
 - [Domain Name](#domain-name)
 - [Extends](#extends)
 - [Requirements](#requirements)
@@ -76,7 +78,7 @@ A domain file in PDDL 1.2 defines the "universal" aspects of a problem. Essentia
 ## Domain Name
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `(domain <name>)`
@@ -85,17 +87,18 @@ A domain always begins by being named. Imediately after we open our first bracke
 
 `(domain construction)`
 
-Note that this name is also used when we're extending a domain. 
+Note that this name is also used when we're extending a domain.
 
 ## Extends
 [back to contents](#contents)
 
-Support: <span style="color:red">Poor</span>  
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
-`(:extends <domain_name>)` 
+`(:extends <domain_name>)`
 
 The `:extends` argument allows a domain to extend another "parent" domain. When the `:extends` argument is used, a domain inherits the following from it's parent
+
 - requirements
 - types
 - constants
@@ -104,9 +107,10 @@ The `:extends` argument allows a domain to extend another "parent" domain. When 
 - timeless propositions
 
 ## Requirements
+
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `(:requirements <requirement_name>)`
@@ -118,7 +122,9 @@ Multiple `:requirements` can be specified through a space separated list e.g.
 `(:requirements :strips :adl :typing)`
 
 ### List of Requirements
+
 The following is a list of requirements as specified in the 1998 technical manual for the AIPS competition, however, not all are supported anymore.
+
 - [:strips](./Domain/requirements.md#STRIPS)
 - [:typing](./Domain/requirements.md#typing)
 - [:disjunctive-preconditions](./Domain/requirements.md#Disjunctive%20Preconditions)
@@ -141,20 +147,23 @@ The following is a list of requirements as specified in the 1998 technical manua
 - [:ucpop](./Domain/requirements.md#UCPOP)
 
 ## Object Types
+
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
-```
+
+```LISP
 (:types
     <type_name_1> ... <type_name_n> - object
     <sub_name_1> ... <sub_name_n> - <type_name_1>
 )
 ```
+
 Typing allows us to create basic and subtypes to which we can apply predicates. We use types to restrict what objects can form the parameters of an action. Types and subtypes allow us to declare both general and specific actions and predicates e.g.
 
-```
-(:types 
+```LISP
+(:types
     site material - object
     bricks cables windows - material
 )
@@ -176,17 +185,18 @@ Which only apply to a specific sub-type.
 
 We can go further and do the same with actions for example.
 
-```
+```LISP
 (:action MOVE-MATERIAL
     :parameters (?s1 - site ?s2 - site ?m -material)
     ...
 )
 ```
+
 Where we wish to express for example the movement of any material from one site to another. The material which we are moving doesn't really matter as it's only being moved. Note that we cannot then use predicates such as `(windows-clean)` within this action as not all `material` has this predicate defined for it.
 
 Alternatively, if we want to use a specific material, such as when we're building a wall we might declare an action like so
 
-```
+```LISP
 (:action BUILD-WALL
     :parameters (?s - site ?b - bricks)
     ...
@@ -196,9 +206,10 @@ Alternatively, if we want to use a specific material, such as when we're buildin
 This action above requires that the specific object is a `bricks` type and therefore we can use predicates which use `bricks`. However, because all `bricks` are `materials` we can also use predicates that take materials for example `(material-used)` within our action.
 
 ## Constants
+
 [back to contents](#contents)
 
-Support: <span style="color:yellow">High</span>  
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:constants mainsite - site)`
@@ -208,9 +219,10 @@ Constants allow us to declare objects that are present across all instances of a
 This isn't particularly common in practice because we would just declare the object repeatedly in each specific problem.
 
 ## Domain Variables
+
 [back to contents](#contents)
 
-Support: <span style="color:pink">Changed</span>  
+Support: <span style="color:pink">Changed</span>
 Usage: <span style="color:red">Rare (in this context)</span>
 
 `(:domain-variables (numthings 2) - integer)`
@@ -220,21 +232,23 @@ Domain variables are an older way of expressing numerics which is redefined in P
 Further, most planners won't support this syntax.
 
 ## Predicates
+
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
-```
+```LISP
 (:predicates
     (<predicate_name> <argument_1> ... <argument_n>)
 )
 ```
+
 Predicates apply to a specific type of object, or to all objects. Predicates are either true or false at any point in a plan and when not declared are assumed to be false (except when the Open World Assumption is included as a requirement).
 
 An example of a predicate declaration can be seen below. In most cases predicate normally take only one or two objects as arguments. But this is not a restriction and predicates can (in theory) take as many arguments as the user wishes.
 
-```
+```LISP
 (:predicates
     (walls-built ?s - site)
     (windows-fitted ?s - site)
@@ -246,16 +260,17 @@ An example of a predicate declaration can be seen below. In most cases predicate
 )
 ```
 
-In this case, when the predicate `(walls-built ?s)` is true for a given site, then we can assume that said site has had walls built on it. When it is false, we would assume that the site does not have walls on it. 
+In this case, when the predicate `(walls-built ?s)` is true for a given site, then we can assume that said site has had walls built on it. When it is false, we would assume that the site does not have walls on it.
 
-In another case, let's say with have multiple sites with various materials distributed across them, we can use the predicate `on-site` to model the location of a material across different sites. e.g. `(on-site bricks1 site1)` implies that the material `bricks1` are currently located on `site1`. 
+In another case, let's say with have multiple sites with various materials distributed across them, we can use the predicate `on-site` to model the location of a material across different sites. e.g. `(on-site bricks1 site1)` implies that the material `bricks1` are currently located on `site1`.
 
 To move the bricks we would create an action which indicates that `(on-site bricks1 site1)` is now false and (assuming `site2` is where we're moving them to) that `(on-site bricks1 site2)` is now true.
 
 ## Timeless Predicates
+
 [back to contents](#contents)
 
-Support: <span style="color:red">Poor</span>  
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:timeless (<predicate_name> <arguments>))`
@@ -265,30 +280,32 @@ A timeless predicate is a predicate which is always true and cannot be changed b
 `(:timeless (foundations-set mainsite))`
 
 ## Safety Constraint
+
 [back to contents](#contents)
 
-Support: <span style="color:red">Poor</span>  
+Support: <span style="color:red">Poor</span>
 Usage: <span style="color:red">Rare</span>
 
 `(:safety <condition>)`
 
 A safety condition is a condition which for any plan to be valid, must be true at the end of the plan. How this differs from a goal condition is not clear.
 
-```
-(:safety 
-    (forall 
+```LISP
+(:safety
+    (forall
         (?s - site) (walls-built ?s)))
 ```
 
 It might be used in order to essentially define global goals, goals which must be met regardless of the specific problem. In reality, these kind of global goals would still be encoded into the problem file.
 
 ## Actions
+
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
-```
+```LISP
 (:action <action_name>
     :parameters (<argument_1> ... <argument_n>)
     :precondition (<logical_expression>)
@@ -308,12 +325,15 @@ The second is the `:precondition` section. These are typically a series of predi
 The third section is a choice between `:effect` and `:expansion` an action cannot have both. Most domains use `:effect`. No details are provided of how to use `:expansion` as not enough planners support it.
 
 ### Action Contents
+
 - [Action Example](#action-example)
 - [Parameters](#parameters)
 - [Preconditions](#preconditions)
 - [Effects](#effects)
+
 ### Action Example
-```
+
+```LISP
 (:action BUILD-WALL
     :parameters (?s - site ?b - bricks)
     :precondition (and
@@ -328,8 +348,11 @@ The third section is a choice between `:effect` and `:expansion` an action canno
     )
 )
 ```
+
+
 ### Parameters
-Support: <span style="color:green">Universal</span>  
+
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `:parameters (argument_1 ... argument_n)`
@@ -338,36 +361,40 @@ Usage: <span style="color:green">High</span>
 
 The parameters defines the type of object we're interested in. Note that a parameter can take any type or subtype. If we have for example three instances of site such as `s1`, `s2` and `s3` and we have two instances of bricks `b1`, `b2`, our planner considers all possible actions such as:
 
-`(BUILD-WALL s1 b1)`  
-`(BUILD-WALL s2 b1)`  
-`(BUILD-WALL s3 b1)`  
-`(BUILD-WALL s1 b2)`  
-`(BUILD-WALL s2 b2)`  
+`(BUILD-WALL s1 b1)`
+`(BUILD-WALL s2 b1)`
+`(BUILD-WALL s3 b1)`
+`(BUILD-WALL s1 b2)`
+`(BUILD-WALL s2 b2)`
 `(BUILD-WALL s3 b2)`
 
 Therefore it is not up to us as a user to specify the specific object to which an action applies but rather the **type** of objects to which the action applies.
 
-In this case, when we build a wall we need to know what bricks we're using to build it and where we're building it. Our actions are specific to the problem we've chosen to consider and model, therefore there might additional things that other user want/need to model that I don't. 
+In this case, when we build a wall we need to know what bricks we're using to build it and where we're building it. Our actions are specific to the problem we've chosen to consider and model, therefore there might additional things that other user want/need to model that I don't.
 
 Your domain and problem should only consider and model the aspects of the problem which you're trying to solve. For example here we haven't modelled the person who's actually going to perform the work, but maybe if we were the manager of a larger building site we might want to and therefore we would need to adapt these models.
 
 #### Either
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:red">Rare</span>
 
 `:parameters (?x - (either bricks windows))`
 
-The `either` term expresses that a parameter may have one of any type within the either expression. In the example above, `?x` can be of either type `bricks` or type `windows`. 
+The `either` term expresses that a parameter may have one of any type within the either expression. In the example above, `?x` can be of either type `bricks` or type `windows`.
 
 This functionality is rarely used in favour of subtyping. However, it might be the case where with direct inheritance it's not possible to group two distinctly different types.
 
 ### Preconditions
-Support: <span style="color:green">Universal</span>  
+
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
-```
+
+```LISP
 :precondition (<logical_expression>)
 ```
-```
+
+```LISP
 :precondition (and
     (on-site ?b ?s)
     (foundations-set ?s)
@@ -385,6 +412,7 @@ The statement above is a conjunction and can be thought of as shown below
 In PDDL `and` and `or` apply across all the predicates within them. For more details on logic keywords see below
 
 #### And
+
 `(and (predicate_1) ... (predicate_n))`
 
 A conjunction of predicates, expressing that all values must be true in order to evaluate to true. e.g.
@@ -392,6 +420,7 @@ A conjunction of predicates, expressing that all values must be true in order to
 `(and (walls-built ?s) (windows-fitted ?s))`
 
 #### Or
+
 `(or (predicate_1) ... (predicate_n))`
 
 A disjunction of predicates, expressing at least one of the values must be true in order to evaluate true. e.g.
@@ -399,6 +428,7 @@ A disjunction of predicates, expressing at least one of the values must be true 
 `(or (windows-fitted ?s) (cables-installed ?s))`
 
 #### Imply
+
 `(imply (antecedent_predicate) (consequent_predicate))`
 
 An implies across an antecedent predicate and a consequence predicate. An implies evaluates true whenever the antecedent is false, or the antecedent and consequent are true. e.g.
@@ -406,6 +436,7 @@ An implies across an antecedent predicate and a consequence predicate. An implie
 `(imply (walls-built ?s) (foundations-set ?s))`
 
 #### Not
+
 `(not (logical_expression/predicate_name))`
 
 Not negates a predicate value or logical expression. In a precondition it expresses that some predicate value or logical expression is false. In an effect it assigns false to a predicate value.
@@ -413,12 +444,13 @@ Not negates a predicate value or logical expression. In a precondition it expres
 `(not (material-used ?b))`
 
 #### Forall
+
 `(forall (argument) logical_expression)`
 
 Forall takes an argument and expresses that some logical expression holds true across it. In this case that all brick objects in the domain have not been used.
 
-```
-(forall (?b - bricks) 
+```LISP
+(forall (?b - bricks)
     (not (material-used ?b))
 )
 ```
@@ -426,18 +458,20 @@ Forall takes an argument and expresses that some logical expression holds true a
 Forall **cannot** be used as an effect.
 
 ##### When
-```
-(forall (argument) 
+
+```LISP
+(forall (argument)
     when (inclusion_expression)
         logical expression
 )
 ```
+
 When extends a forall condition to specify an inclusion condition. Essentially it says `forall` these objects `when` these conditions are met check that these conditions are met.
 
 e.g.
 
-```
-(forall (?c - bricks) 
+```LISP
+(forall (?c - bricks)
     when (on-site ?c ?s)
         (material-used ?c)
 )
@@ -446,12 +480,14 @@ e.g.
 Is expressing that `forall` bricks, that meet the condition `on-site ?c ?s` they must also meet the condition that they've been used `material-used ?c`.
 
 #### Exists
+
 `(exists (argument) logical_expression)`
 
 Exists expresses the same as `forall` except rather than expressing that every object of a given type meet a logical expression, it expresses that at least one meets the logical expression.
 
 e.g.
-```
+
+```LISP
 (exists
     (?c - bricks)
         (not (material-used ?c))
@@ -461,12 +497,13 @@ e.g.
 Exists **cannot** be used as an effect.
 
 ### Effects
-Support: <span style="color:green">Universal</span>  
+
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `:effect (logical_expression)`
 
-```
+```LISP
 :effect (and
     (walls-built ?s)
     (material-used ?b)
@@ -478,6 +515,7 @@ An effect consists of a conjunctive logical expression, which defines which valu
 This limits us to using `and` and `not` to express the effects of an action. Although in theory we could also use `forall` as well, this is not supported and does not fit well with the modelling process as typically we take all of the objects (and therefore predicates) which we are planning to have an `effect` on as `parameters`.
 
 #### And
+
 `(and (predicate_1) ... (predicate_n))`
 
 A conjunction of predicates, expressing that all values must be true in order to evaluate to true. e.g.
@@ -485,6 +523,7 @@ A conjunction of predicates, expressing that all values must be true in order to
 `(and (walls-built ?s) (windows-fitted ?s))`
 
 #### Not
+
 `(not (logical_expression/predicate_name))`
 
 Not negates a predicate value or logical expression. In a precondition it expresses that some predicate value or logical expression is false. In an effect it assigns false to a predicate value.
@@ -492,11 +531,13 @@ Not negates a predicate value or logical expression. In a precondition it expres
 `(not (material-used ?b))`
 
 ## Axioms
+
 [back to contents](#contents)
 
-Support: <span style="color:yellow">High</span>  
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:orange">Low</span>
-```
+
+```LISP
 (:axiom
     :vars (arguments)
     :context (logical_expression)
@@ -504,8 +545,7 @@ Usage: <span style="color:orange">Low</span>
 )
 ```
 
-
-```
+```LISP
 (:axiom
     :vars (?s - site)
     :context (and
@@ -517,12 +557,13 @@ Usage: <span style="color:orange">Low</span>
 )
 ```
 
-An axiom is a derived predicate which essentially takes its value as the result of evaluating a logical expression over other predicates. 
+An axiom is a derived predicate which essentially takes its value as the result of evaluating a logical expression over other predicates.
 
-In the example above, we're saying that for any given building site, if the walls are built (`walls-built`) and the windows are fitted (`windows-fitted`) and the cables installed (`cables-installed`) then this means the site is built (`site-built`). 
+In the example above, we're saying that for any given building site, if the walls are built (`walls-built`) and the windows are fitted (`windows-fitted`) and the cables installed (`cables-installed`) then this means the site is built (`site-built`).
 
 This is quite useful if there is a logical expression you're using repeatedly in several locations, as you can simply reduce it to a single predicate. However, this syntax is not commonly used.
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [OPTIC - Optimising Preferences and Time Dependent Costs](https://nms.kcl.ac.uk/planning/software/optic.html)

--- a/docs/reference/PDDL/main.md
+++ b/docs/reference/PDDL/main.md
@@ -1,10 +1,15 @@
 # PDDL 1.2
+
 [return to homepage](../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
+
 ## Introduction
-PDDL 1.2 formed the basis of the 1998 AIPS Competition. PDDL 1.2 is based largely on concepts set out for STRIPS, a sort of precursor languages which used a similar design pattern for describing problems through the use of predicates and actions. 
+
+PDDL 1.2 formed the basis of the 1998 AIPS Competition. PDDL 1.2 is based largely on concepts set out for STRIPS, a sort of precursor languages which used a similar design pattern for describing problems through the use of predicates and actions.
 
 Problems in PDDL are defined in two parts, a domain and a problem file. The following sections divide respectively, representing constituent parts of the domain and the problem.
+
 ## Contents
+
 - [Domain](./domain.md)
     - [Extends](./domain.md#extends)
     - [Requirements](./domain.md#requirements)
@@ -25,16 +30,18 @@ Problems in PDDL are defined in two parts, a domain and a problem file. The foll
     - [Goal](./problem.md#goal)
 
 ## Domain And Problem File
+
 ### Domain
-```PDDL
+
+```LISP
 (define
     (domain construction)
     (:extends building)
     (:requirements :strips :typing)
-    (:types 
+    (:types
         site material - object
         bricks cables windows - material
-    )x
+    )
     (:constants mainsite - site)
 
     ;(:domain-variables ) ;deprecated
@@ -51,9 +58,9 @@ Problems in PDDL are defined in two parts, a domain and a problem file. The foll
 
     (:timeless (foundations-set mainsite))
 
-    ;(:safety 
-        (forall 
-            (?s - site) (walls-built ?s)))
+    ;(:safety
+        ;(forall
+        ;    (?s - site) (walls-built ?s)))
         ;deprecated
 
     (:action BUILD-WALL
@@ -71,7 +78,7 @@ Problems in PDDL are defined in two parts, a domain and a problem file. The foll
         ; :expansion ;deprecated
     )
 
-    ;(:axiom
+    (:axiom
         :vars (?s - site)
         :context (and
             (walls-built ?s)
@@ -86,15 +93,16 @@ Problems in PDDL are defined in two parts, a domain and a problem file. The foll
 ```
 
 ### Problem File
-```PDDL
+
+```LISP
 (define
     (problem buildingahouse)
     (:domain construction)
     ;(:situation <situation_name>) ;deprecated
-    (:objects 
-        s1 - site 
-        b - bricks 
-        w - windows 
+    (:objects
+        s1 - site
+        b - bricks
+        w - windows
         c - cables
     )
     (:init
@@ -112,5 +120,6 @@ Problems in PDDL are defined in two parts, a domain and a problem file. The foll
 ```
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [OPTIC - Optimising Preferences and Time Dependent Costs](https://nms.kcl.ac.uk/planning/software/optic.html)

--- a/docs/reference/PDDL/problem.md
+++ b/docs/reference/PDDL/problem.md
@@ -1,11 +1,12 @@
 # Problem
+
 [return to homepage](../../readme.md) | [return to PDDL main page](./main.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 A problem forms the other half of a planning problem. In the domain we express the global "worldly" aspects of a problem, such as what actions we can perform and what types of objects exist in the world we're planning in.
 
 The problem then solidifies this expression by define exactly what objects exist, and what is true about them and then finally what the end goal is. What state we want the world to be in once the plan is finished.
 
-```PDDL
+```LISP
 (define
     (problem buildingahouse)
     (:domain construction)
@@ -31,6 +32,7 @@ The problem then solidifies this expression by define exactly what objects exist
 ```
 
 ## Contents
+
 - [Problem Name](#problem-name)
 - [Domain](#domain)
 - [Situation](#situation)
@@ -39,6 +41,7 @@ The problem then solidifies this expression by define exactly what objects exist
 - [Goal](#goal)
 
 ## Problem Name
+
 [back to contents](#contents)
 
 Support: <span style="color:green">Universal</span>  
@@ -51,6 +54,7 @@ Each problem is given a name, typically this is a unique identifier. This is to 
 `(problem buildingahouse)`
 
 ## Domain
+
 [back to contents](#contents)
 
 Support: <span style="color:green">Universal</span>  
@@ -63,6 +67,7 @@ The domain argument refers to the domain in which the problem exists (see [Domai
 `(:domain construction)`
 
 ## Situation
+
 [back to contents](#contents)
 
 Support: <span style="color:orange">Low</span>  
@@ -77,12 +82,13 @@ The use of situation is not very common and most problem files will define even 
 `(:situation generalbuildingproblem)`
 
 ## Objects
+
 [back to contents](#contents)
 
 Support: <span style="color:green">Universal</span>  
 Usage: <span style="color:green">High</span>
 
-```
+```LISP
 (:objects
     object_name_1 ... object_name_n - some_object_type
     ...
@@ -92,7 +98,7 @@ Usage: <span style="color:green">High</span>
 
 The objects block allows us to declare a set of objects which exist within our problem. each object name must be unique, and should be typed. If not typed then they will typically take on the properties of the base type `object` (see [Domain - Object Types](./domain#Object%20Types) for details)
 
-```
+```LISP
 (:objects
     s1 s2 s3 - site
     ba bb bc - bricks
@@ -103,7 +109,7 @@ The objects block allows us to declare a set of objects which exist within our p
 
 Note that whilst conventionally we would just use an abbreviation followed by a number, we are not required to, and can use even ridiculously unhelpful names (as shown above).
 
-```
+```LISP
 (:objects 
     s1 - site 
     b - bricks 
@@ -113,12 +119,13 @@ Note that whilst conventionally we would just use an abbreviation followed by a 
 ```
 
 ## Init
+
 [back to contents](#contents)
 
 Support: <span style="color:green">Universal</span>  
 Usage: <span style="color:green">High</span>
 
-```
+```LISP
 (:init
     <predicate>
     ...
@@ -128,7 +135,7 @@ Usage: <span style="color:green">High</span>
 
 The initial state (init) defines specifically what predicates are true at the start of the problem. This is **not** a logical expression because it is simply a list of predicates which are true. Unless the planner or domain specify otherwise all problems have the "closed world" assumption applied meaning anything not specified as true is considered false. Therefore we only need to list things which are true.
 
-```
+```LISP
 (:init
     (on-site b s1)
     (on-site c s1)
@@ -139,11 +146,13 @@ The initial state (init) defines specifically what predicates are true at the st
 In the case of our domain and problem, the only facts which are true are that the materials we need to build are `on-site`.
 
 ## Goal
+
 [back to contents](#contents)
 
 Support: <span style="color:green">Universal</span>  
 Usage: <span style="color:green">High</span>
-```
+
+```LISP
 (:goal logical_expression)
 ```
 
@@ -151,7 +160,7 @@ The goal is a logical expression of predicates which must be satisfied in order 
 
 Note that all standard logical operators such as `or` and `forall` are available as part of the goal, which means we can express multiple different goal states all of which are acceptable.
 
-```
+```LISP
 (:goal (and
         (walls-built ?s1)
         (cables-installed ?s1)
@@ -163,6 +172,7 @@ Note that all standard logical operators such as `or` and `forall` are available
 Typically most goals are just conjunctions and negations as there is only one desirable state at the end of the plan.
 
 #### And
+
 `(and (predicate_1) ... (predicate_n))`
 
 A conjunction of predicates, expressing that all values must be true in order to evaluate to true. e.g.
@@ -170,6 +180,7 @@ A conjunction of predicates, expressing that all values must be true in order to
 `(and (walls-built ?s) (windows-fitted ?s))`
 
 #### Or
+
 `(or (predicate_1) ... (predicate_n))`
 
 A disjunction of predicates, expressing at least one of the values must be true in order to evaluate true. e.g.
@@ -177,6 +188,7 @@ A disjunction of predicates, expressing at least one of the values must be true 
 `(or (windows-fitted ?s) (cables-installed ?s))`
 
 #### Imply
+
 `(imply (antecedent_predicate) (consequent_predicate))`
 
 An implies across an antecedent predicate and a consequence predicate. An implies evaluates true whenever the antecedent is false, or the antecedent and consequent are true. e.g.
@@ -184,6 +196,7 @@ An implies across an antecedent predicate and a consequence predicate. An implie
 `(imply (walls-built ?s) (foundations-set ?s))`
 
 #### Not
+
 `(not (logical_expression/predicate_name))`
 
 Not negates a predicate value or logical expression. In a precondition it expresses that some predicate value or logical expression is false. In an effect it assigns false to a predicate value.
@@ -191,28 +204,31 @@ Not negates a predicate value or logical expression. In a precondition it expres
 `(not (material-used ?b))`
 
 #### Forall
+
 `(forall (argument) logical_expression)`
 
 Forall takes an argument and expresses that some logical expression holds true across it. In this case that all brick objects in the domain have not been used.
 
-```
+```LISP
 (forall (?b - bricks) 
     (not (material-used ?b))
 )
 ```
 
 ##### When
-```
+
+```LISP
 (forall (argument) 
     when (inclusion_expression)
         logical expression
 )
 ```
+
 When extends a forall condition to specify an inclusion condition. Essentially it says `forall` these objects `when` these conditions are met check that these conditions are met.
 
 e.g.
 
-```
+```LISP
 (forall (?c - bricks) 
     when (on-site ?c ?s)
         (material-used ?c)
@@ -222,12 +238,14 @@ e.g.
 Is expressing that `forall` bricks, that meet the condition `on-site ?c ?s` they must also meet the condition that they've been used `material-used ?c`.
 
 #### Exists
+
 `(exists (argument) logical_expression)`
 
 Exists expresses the same as `forall` except rather than expressing that every object of a given type meet a logical expression, it expresses that at least one meets the logical expression.
 
 e.g.
-```
+
+```LISP
 (exists
     (?c - bricks)
         (not (material-used ?c))
@@ -235,5 +253,6 @@ e.g.
 ```
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [OPTIC - Optimising Preferences and Time Dependent Costs](https://nms.kcl.ac.uk/planning/software/optic.html)

--- a/docs/reference/PDDL2.1/Domain/requirements.md
+++ b/docs/reference/PDDL2.1/Domain/requirements.md
@@ -1,9 +1,11 @@
 # Requirements (PDDL 2.1)
+
 [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 The following page offers details of requirements defined in PDDL 2.1.
 
 ## Numeric Fluents
+
 Support: <span style="color:yellow">High</span>  
 Usage: <span style="color:green">High</span>
 
@@ -11,14 +13,16 @@ Usage: <span style="color:green">High</span>
 
 Allows the inclusion of a `:function` block which represent numeric variables in the domain. e.g.
 
-`(:functions
+```LISP
+(:functions
     (battery-amount ?r - rover)
 )
-`
+```
 
 Note that this overrides the definition in PDDL1.2 in most planners.
 
 ## Durative Actions
+
 Support: <span style="color:yellow">High</span>  
 Usage: <span style="color:green">High</span>
 
@@ -26,7 +30,7 @@ Usage: <span style="color:green">High</span>
 
 Allows the use of `durative-action` in the domain definition. Durative actions are actions which have a duration they take to complete.
 
-```
+```LISP
 (:durative-action move
     :parameters (<arguments>)
     :duration (= ?duration 5)
@@ -38,6 +42,7 @@ Allows the use of `durative-action` in the domain definition. Durative actions a
 Note that this does **not** imply `:fluents`
 
 ## Durative Inequalities
+
 Support: <span style="color:yellow">High</span>  
 Usage: <span style="color:green">High</span>
 
@@ -46,6 +51,7 @@ Usage: <span style="color:green">High</span>
 Allows the use of inequalities to express a duration. Rather than expressing that an action has a fixed length of time we can express that an action has a duration range using an inequality.
 
 ## Continuous Effects
+
 Support: <span style="color:orange">Medium</span>  
 Usage: <span style="color:green">High</span>
 
@@ -54,6 +60,7 @@ Usage: <span style="color:green">High</span>
 Allows the use of continuous effects on numerics within durative actions. Because durative actions take a period of time, we could model the change in a numeric value as some function of time. In reality support for this shaky. Linear functions are relatively easy for planners but non-linear effects are still an area of research.
 
 ## Negative Preconditions
+
 Support: <span style="color:red">Low</span>  
 Usage: <span style="color:green">High</span>
 
@@ -64,6 +71,7 @@ Allows the use of `not` in preconditions. The way some planners model actions me
 `rover-charged` and `rover-not-charged` are mutually exclusive. In the event where negative preconditions are not support we can introduce a second predicate which represents the negation of the predicate we want to express a negative precondition on.
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL Examples](https://github.com/yarox/pddl-examples)

--- a/docs/reference/PDDL2.1/domain.md
+++ b/docs/reference/PDDL2.1/domain.md
@@ -1,12 +1,15 @@
 # Domain
 [return to homepage](../../readme.md) | [return to PDDL2.1 main page](./main.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
-The domain syntax in PDDL2.1 extended upon version 1.2 to include two key new features, `durative-actions` and `functions` which are referred to as numeric fluents. Additional new requirements were specified on top of the 1.2 spec to allow older planners to identify that they could not solve these neweer domains. 
+The domain syntax in PDDL2.1 extended upon version 1.2 to include two key new features, `durative-actions` and `functions` which are referred to as numeric fluents. Additional new requirements were specified on top of the 1.2 spec to allow older planners to identify that they could not solve these neweer domains.
 
-```
+```LISP
 (define (domain rover-domain)
     (:requirements :durative-actions :fluents :duration-inequalities)
     (:types rover waypoint)
+    (:predicates
+        ... ; Predicates omitted
+	)
     (:functions
         (battery-amount ?r - rover)
         (sample-amount ?r - rover)
@@ -15,33 +18,30 @@ The domain syntax in PDDL2.1 extended upon version 1.2 to include two key new fe
         (sample-capacity)
         (distance-travelled)
     )
-    (:predicates
-        ... ; Predicates omitted              
-	)
-	     
+
     (:durative-action move
-        :parameters 
+        :parameters
             (?r - rover
-             ?fromwp - waypoint 
+             ?fromwp - waypoint
              ?towp - waypoint)
-        
-        :duration 
+
+        :duration
             (= ?duration 5)
-        
+
         :condition
-	        (and 
-	            (at start (rover ?rover)) 
-	            (at start (waypoint ?from-waypoint)) 
-	            (at start (waypoint ?to-waypoint)) 
-	            (over all (can-move ?from-waypoint ?to-waypoint)) 
-	            (at start (at ?rover ?from-waypoint)) 
+	        (and
+	            (at start (rover ?rover))
+	            (at start (waypoint ?from-waypoint))
+	            (at start (waypoint ?to-waypoint))
+	            (over all (can-move ?from-waypoint ?to-waypoint))
+	            (at start (at ?rover ?from-waypoint))
 	            (at start (> (battery-amount ?rover) 8)))
-	            
+
         :effect
-	        (and 
+	        (and
 	            (at end (at ?rover ?to-waypoint))
 	            (at end (been-at ?rover ?to-waypoint))
-	            (at start (not (at ?rover ?from-waypoint))) 
+	            (at start (not (at ?rover ?from-waypoint)))
 	            (at start (decrease (battery-amount ?rover) 8))
                 (at end (increase (distance-travelled) 5))
                 )
@@ -50,8 +50,8 @@ The domain syntax in PDDL2.1 extended upon version 1.2 to include two key new fe
 )
 ```
 
-
 ## Contents
+
 - [Requirements](#requirements)
 - [Numeric Fluents](#numeric-fluents)
 - [Durative Actions](#durative-actions)
@@ -61,21 +61,28 @@ The domain syntax in PDDL2.1 extended upon version 1.2 to include two key new fe
     - [:effect](#effect)
 
 ## Requirements
+
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
-`(:requirements <requirement_name>)`
+```LISP
+(:requirements <requirement_name>)
+```
 
 Requirements are similar to import/include statements in programming languages, however as PDDL is a kind of declarative language, it is a `:requirement` as a given planner is "required" to facilitate some aspect of the language.
 
 Multiple `:requirements` can be specified through a space separated list e.g.
 
-`(:requirements :strips :adl :typing)`
+```LISP
+(:requirements :strips :adl :typing)
+```
 
 ### List of Requirements
-The following is a list of requirements that were added by PDDL2.1 to the language of PDDL. 
+
+The following is a list of requirements that were added by PDDL2.1 to the language of PDDL.
+
 - [:fluents](./Domain/requirements.md#Numeric%20Fluents)
 - [:durative-actions](./Domain/requirements.md#Durative%20Actions)
 - [:durative-inequalities](./Domain/requirements.md#Durative%20Inequalities)
@@ -83,12 +90,13 @@ The following is a list of requirements that were added by PDDL2.1 to the langua
 - [:negative-preconditions](./Domain/requirements.md#Negative%20Preconditions)
 
 ## Numeric Fluents
+
 [back to contents](#contents)
 
-Support: <span style="color:yellow">High</span>  
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:green">High</span>
 
-```
+```LISP
 (:functions
     (<variable_name> <parameter_name> - <object_type>)
     ...
@@ -98,7 +106,7 @@ Usage: <span style="color:green">High</span>
 
 A numeric fluent, similar to a predicate, is a variable which applies to zero or more objects and maintains a value throughout the duration of the plan. It is declared with a name followed by the object type to which it applies. e.g.
 
-```
+```LISP
 (:functions
     (battery-level ?r - rover)
 )
@@ -106,7 +114,7 @@ A numeric fluent, similar to a predicate, is a variable which applies to zero or
 
 Means that every rover object in the domain has a variable which maintains a value for `battery-level`. A function can apply to zero or more objects, meaning we could also use it to represent a numeric value between two values, for example a distance.
 
-```
+```LISP
 (:functions
     (distance ?wp1 - waypoint ?wp2 - waypoint)
 )
@@ -114,77 +122,120 @@ Means that every rover object in the domain has a variable which maintains a val
 
 Numeric fluents can be altered through the effects of both `action`s and `durative-action`s. There are a number of supported effects for numeric fluents.
 
-### Prefix Maths
-Support: <span style="color:yellow">High</span>  
+### Prefix Maths (Numeric Expressions)
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:green">High</span>
+
 #### Add
-`(+ (sample-capacity) (battery-capacity))`
+
+```LISP
+(+ (sample-capacity) (battery-capacity))
+```
+
 #### Subtract
-`(- (sample-capacity) (battery-capacity))`
+
+```LISP
+(- (sample-capacity) (battery-capacity))
+```
+
 #### Divide
-`(/ (sample-capacity) (battery-capacity))`
+
+```LISP
+(/ (sample-capacity) (battery-capacity))
+```
+
 #### Multiply
-`(* (sample-capacity) (battery-capacity))`
+
+```LISP
+(* (sample-capacity) (battery-capacity))
+```
 
 Prefix notation is used to represent maths operations on numeric fluents. We can see the four primarily binary operations we can perform on numeric fluents. In all of these cases, to convert to infix notation we place the operator between the name of the two fluents.
 
 ### Increase
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:green">High</span>
 
-`(increase (battery-level ?r) 10)`
+```LISP
+(increase (battery-level ?r) 10)
+```
 
 An increase effect increases the value of a numeric variable by the given amount. It is possible to use another numeric variable as the increase value for example.
 
-`(increase (battery-level ?r) (charge-available - ?solarpanel))`
+```LISP
+(increase (battery-level ?r) (charge-available - ?solarpanel))
+```
 
 ### Decrease
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:green">High</span>
 
-`(decrease (battery-level ?r) 10)`
+```LISP
+(decrease (battery-level ?r) 10)
+```
 
 A decrease effect decreases the value of a numeric variable by the given amount. It is possible to use another numeric variable as the decrease value for example.
 
-`(decrease (battery-level ?r) (power-needed-for-work - ?task))`
+```LISP
+(decrease (battery-level ?r) (power-needed-for-work - ?task))
+```
 
 ### Assign
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:green">High</span>
 
-`(assign (battery-level ?r) 10)`
+```LISP
+(assign (battery-level ?r) 10)
+```
 
 An assign effect assigns the value of a numeric variable to the given amount. It is possible to use another numeric variable as the assign value for example.
 
-`(assign (battery-level ?r) (max-charge ?r))`
+```LISP
+(assign (battery-level ?r) (max-charge ?r))
+```
 
 ### Scale Up
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:red">Rare</span>
 
-`(scale-up (battery-level ?r) 2)`
+```LISP
+(scale-up (battery-level ?r) 2)
+```
 
 A scale up effect increases the value of the numeric variable by the given scale factor. The scale factor can be another numeric variable.
 
-`(scale-up (battery-level ?r) (charge-rate ?r))`
+```LISP
+(scale-up (battery-level ?r) (charge-rate ?r))
+```
 
 ### Scale Down
-Support: <span style="color:yellow">High</span>  
+
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:red">Rare</span>
 
-`(scale-down (battery-level ?r) 2)`
+```LISP
+(scale-down (battery-level ?r) 2)
+```
 
 A scale down effect decreases the value of the numeric variable by the given scale factor. The scale factor can be another numeric variable.
 
-`(scale-down (battery-level ?r) (consumption-rate ?r))`
+```LISP
+(scale-down (battery-level ?r) (consumption-rate ?r))
+```
 
 ## Durative Actions
+
 [back to contents](#contents)
 
-Support: <span style="color:yellow">High</span>  
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:green">High</span>
 
-```
+```LISP
 (:durative-action <action_name>
     :parameters (<arguments>)
     :duration (= ?duration <duration_number>)
@@ -193,96 +244,131 @@ Usage: <span style="color:green">High</span>
 )
 ```
 
-A durative action is an action which represents an action which takes an amount of time to complete. The amount of time is expressable as either a value or as an inequality (allow for both fixed duration and ranged duration actions). Similar to traditional `action`s we have `condition`s and `effect`s, but it should be noted that the keyword in durative actions is `condition` **NOT** `precondition`. 
+A durative action is an action which represents an action which takes an amount of time to complete. The amount of time is expressable as either a value or as an inequality (allow for both fixed duration and ranged duration actions). Similar to traditional `action`s we have `condition`s and `effect`s, but it should be noted that the keyword in durative actions is `condition` **NOT** `precondition`.
 
 This semantic change is designed to represent that a durative action may not just condition when the action starts, but may have conditions which need to be true at the end or over the duration of the action. A good example of this can be found in flight planning, where an action `fly` requires that a runway be free at the start and end of an action, in order for the plane to take off and land, whilst the runway does not need to be free whilst the plane is flying.
 
 ### Parameters
-Support: <span style="color:green">Universal</span>  
+
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
-`:parameters (argument_1 ... argument_n)`
+```LISP
+:parameters (argument_1 ... argument_n)
+```
 
-`:parameters (?s -site ?b - bricks)`
+```LISP
+:parameters (?s -site ?b - bricks)
+```
 
 The parameters defines the type of object we're interested in. Note that a parameter can take any type or subtype. If we have for example three instances of site such as `s1`, `s2` and `s3` and we have two instances of bricks `b1`, `b2`, our planner considers all possible actions such as:
 
-`(BUILD-WALL s1 b1)`  
-`(BUILD-WALL s2 b1)`  
-`(BUILD-WALL s3 b1)`  
-`(BUILD-WALL s1 b2)`  
-`(BUILD-WALL s2 b2)`  
+`(BUILD-WALL s1 b1)`
+`(BUILD-WALL s2 b1)`
+`(BUILD-WALL s3 b1)`
+`(BUILD-WALL s1 b2)`
+`(BUILD-WALL s2 b2)`
 `(BUILD-WALL s3 b2)`
 
 Therefore it is not up to us as a user to specify the specific object to which an action applies but rather the **type** of objects to which the action applies.
 
-In this case, when we build a wall we need to know what bricks we're using to build it and where we're building it. Our actions are specific to the problem we've chosen to consider and model, therefore there might additional things that other user want/need to model that this model doesn't. 
+In this case, when we build a wall we need to know what bricks we're using to build it and where we're building it. Our actions are specific to the problem we've chosen to consider and model, therefore there might additional things that other user want/need to model that this model doesn't.
 
 Your domain and problem should only consider and model the aspects of the problem which you're trying to solve. For example here we haven't modelled the person who's actually going to perform the work, but maybe if we were the manager of a larger building site we might want to and therefore we would need to adapt my models.
 
 ### Duration
-Support: <span style="color:green">Universal - where durative actions are available</span>  
+
+Support: <span style="color:green">Universal - where durative actions are available</span>
 Usage: <span style="color:green">High</span>
 
 #### Fixed Value:
 
-`:duration (= ?duration <duration_number>)`
+```LISP
+:duration (= ?duration <duration_number>)
+```
 
-#### Inequality Value:
+#### Inequality Value
 
-`:duration (> ?duration <duration_number>)`
+```LISP
+:duration (> ?duration <duration_number>)
+```
 
-`:duration (< ?duration <duration_number>)`
+```LISP
+:duration (< ?duration <duration_number>)
+```
+
+```LISP
+:duration (and
+    (> ?duration <duration_number>)
+    (< ?duration <duration_number>))
+```
 
 A duration can be expressed as either a fixed value or an inequality. It is also possible to express duration as the value of a Numeric Fluent, which means an action such as `move` can have a `duration` dependent on say `distance` between two points.
 
-`:duration (= ?duration 10)`
+```LISP
+:duration (= ?duration 10)
+```
 
 ### Condition
-Support: <span style="color:green">Universal - where durative actions are available</span>  
+
+Support: <span style="color:green">Universal - where durative actions are available</span>
 Usage: <span style="color:green">High</span>
 
-`:condition (<logical_temporal_expression>)`
+```LISP
+:condition (<logical_temporal_expression>)
+```
 
 A condition is a logical and temporal expression which must be met in order for a durative action to execute. Because a durative action occurs over time, we may wish to express that additional conditions be met for the duration or end of the action, not just the start. This gives rise to three new keywords `at start`, `at end` and `over all`.
 
 #### At Start
+
 An expression or predicate with `at start` prefixed to it, means that the condition must be true at the start of the action in order for the action to be applied. e.g.
 
-`(at start (at ?rover ?from-waypoint)) `
+```LISP
+(at start (at ?rover ?from-waypoint))
+```
 
-expresses that `at start` the given `rover` is `at` the `from-waypoint`. Confusingly in this particular domain, the `at` is a predicate representing the location of an object `at` a point, whilst `at start` is a keyword. 
+expresses that `at start` the given `rover` is `at` the `from-waypoint`. Confusingly in this particular domain, the `at` is a predicate representing the location of an object `at` a point, whilst `at start` is a keyword.
 
 `at start` is usually applied per predicate.
 
 #### At End
+
 An expression or predicate with `at end` prefixed to it, means that the condition must be true at the end of the action in order for the action to be applied e.g.
 
-`(at end (>= (battery-amount ?rover) 0)`
+```LISP
+(at end (>= (battery-amount ?rover) 0)
+```
 
 In essence we are saying that whilst this fact doesn't have to be true at the start or during the action, it must be true at the end. In this case, we're expressing that the battery amount at the end of the action must be greater than zero.
 
 #### Over All
+
 An expression or predicate with an `overall` prefixed to it, means that the condition must be true throughout the action, including at the start and end. e.g.
 
-`(over all (can-move ?from-waypoint ?to-waypoint))`
+```LISP
+(over all (can-move ?from-waypoint ?to-waypoint))
+```
 
 At all points in the execution of the action the given expression must evaluate to true. In the case above, we are expressing that it must be possible to move from the `from` waypoint to the `to` waypoint all the way through the action. I.e. we don't want to get half way through the action to find that after a certain point a path has become blocked.
 
 ### Effect
-Support: <span style="color:green">Universal - where durative actions are available</span>  
+
+Support: <span style="color:green">Universal - where durative actions are available</span>
 Usage: <span style="color:green">High</span>
 
-`:effect (<logical_temporal_condition>)`
+```LISP
+:effect (<logical_temporal_condition>)
+```
 
-An effect similar to in traditional actions, is a condition which is made true when an action is applied. Note that the effect is always more restrictive and typically only allows `and` and `not` as logical expressions. 
+An effect similar to in traditional actions, is a condition which is made true when an action is applied. Note that the effect is always more restrictive and typically only allows `and` and `not` as logical expressions.
 
 Temporal expressions, such as `at start` and `at end` are available, however, `over all` is typically not used. because it's not common to express a boolean effect which is true over the duration of the action. Instead you would set it to true at the start, using an `at start` and set it to false at the end using `at end`
 
-```
+```LISP
 :effect
-    (and 
-        (at start (not (at ?rover ?from-waypoint))) 
+    (and
+        (at start (not (at ?rover ?from-waypoint)))
         (at start (decrease (battery-amount ?rover) 8)))
         (at end (at ?rover ?to-waypoint))
         (at end (been-at ?rover ?to-waypoint))
@@ -291,6 +377,7 @@ Temporal expressions, such as `at start` and `at end` are available, however, `o
 The above effect is saying that `at start` the rover can no longer be considered as being at the `from` waypoint, and that `at end` it can now be considered as being at the `to` waypoint. It also adds a second predicate `been-at` which indicates that at some point the rover has visited the given waypoint.
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL Examples](https://github.com/yarox/pddl-examples)

--- a/docs/reference/PDDL2.1/main.md
+++ b/docs/reference/PDDL2.1/main.md
@@ -1,11 +1,15 @@
 # PDDL 2.1
+
 [return to homepage](../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
+
 ## Introduction
+
 PDDL 2.1 was the language of the 2002 AIPS Competition and built upon the syntax defined for [PDDL 1.2](../PDDL/main). In the 2002 Competition, planners were set the challenge of considering more complicated domains and problems which feature both temporal and numeric considerations (scheduling and resources). As a result, additions the language were necessary to facilitate modelling time and numbers.
 
 This guide will only show features that have been changed or added to PDDL 1.2 in order to form 2.1
 
 ## Contents
+
 - [Domain](./domain.md)
     - [Requirements](./domain.md#requirements)
         - [List of PDDL 2.1 Requirements](./domain.md#list-of-requirements)
@@ -21,8 +25,10 @@ This guide will only show features that have been changed or added to PDDL 1.2 i
     - [Length (Deprecated)](./problem.md#length)
 
 ## Domain And Problem File
+
 ### Domain
-```
+
+```LISP
 (define (domain rover-domain)
     (:requirements :durative-actions :fluents :duration-inequalities)
     (:types rover waypoint)
@@ -35,32 +41,32 @@ This guide will only show features that have been changed or added to PDDL 1.2 i
         (distance-travelled)
     )
     (:predicates
-        ... ; Predicates omitted              
+        ... ; Predicates omitted
 	)
-	     
+
     (:durative-action move
-        :parameters 
+        :parameters
             (?r - rover
-             ?fromwp - waypoint 
+             ?fromwp - waypoint
              ?towp - waypoint)
-        
-        :duration 
+
+        :duration
             (= ?duration 5)
-        
+
         :condition
-	        (and 
-	            (at start (rover ?rover)) 
-	            (at start (waypoint ?from-waypoint)) 
-	            (at start (waypoint ?to-waypoint)) 
-	            (over all (can-move ?from-waypoint ?to-waypoint)) 
-	            (at start (at ?rover ?from-waypoint)) 
+	        (and
+	            (at start (rover ?rover))
+	            (at start (waypoint ?from-waypoint))
+	            (at start (waypoint ?to-waypoint))
+	            (over all (can-move ?from-waypoint ?to-waypoint))
+	            (at start (at ?rover ?from-waypoint))
 	            (at start (> (battery-amount ?rover) 8)))
-	            
+
         :effect
-	        (and 
+	        (and
 	            (at end (at ?rover ?to-waypoint))
 	            (at end (been-at ?rover ?to-waypoint))
-	            (at start (not (at ?rover ?from-waypoint))) 
+	            (at start (not (at ?rover ?from-waypoint)))
 	            (at start (decrease (battery-amount ?rover) 8))
                 (at end (increase (distance-travelled) 5))
                 )
@@ -68,8 +74,10 @@ This guide will only show features that have been changed or added to PDDL 1.2 i
     ... ; Additional actions omitted
 )
 ```
+
 ### Problem
-```
+
+```LISP
 (define
     (problem rover1)
     (:domain rover-domain)
@@ -95,6 +103,7 @@ This guide will only show features that have been changed or added to PDDL 1.2 i
 ```
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL Examples](https://github.com/yarox/pddl-examples)

--- a/docs/reference/PDDL2.1/problem.md
+++ b/docs/reference/PDDL2.1/problem.md
@@ -1,9 +1,10 @@
 # Problem
+
 [return to homepage](../../readme.md) | [return to PDDL2.1 main page](./main.md)
 
 The problem syntax in PDDL 2.1 has to be extended in order to complement the syntax of the domain file. One interesting extension to the syntax in PDDL 2.1 is the addition of a metric. A metric, which behaves like an optimisation function, defines a cost value for a plan. We then express whether we want this metric to be maximised (like in football) or minimised (like in golf).
 
-```
+```LISP
 (define
     (problem rover1)
     (:domain rover-domain)
@@ -29,26 +30,29 @@ The problem syntax in PDDL 2.1 has to be extended in order to complement the syn
 ```
 
 ## Contents
+
 - [Numeric Fluents](#numeric-fluents)
 - [Metric](#metric)
 - [Length (Deprecated)](#length)
 
 ## Numeric Fluents
+
 [back to contents](#contents)
 
-Support: <span style="color:yellow">High</span>  
+Support: <span style="color:yellow">High</span>
 Usage: <span style="color:green">High</span>
 
 `(= (<fluent_name> <argument>) <value>)`
 
-An equals prefix notation is used to assign a value to a numeric fluent. Some planners will require all possible numeric values for numeric fluents should be declared before it will attempt to plan. 
+An equals prefix notation is used to assign a value to a numeric fluent. Some planners will require all possible numeric values for numeric fluents should be declared before it will attempt to plan.
 
 `(= (battery-amount r1) 10)`
 
 ## Metric
+
 [back to contents](#contents) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
-Support: <span style="color:orange">Medium</span>  
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:green">High</span>
 
 `(:metric minimize (<numeric_operation>))`
@@ -60,14 +64,16 @@ A metric can be defined using some numeric operation on fluents, including using
 We can choose to either minimize or maximize the value of the metric function. Note, a metric function is NOT a replacement for a goal.
 
 ## Length
+
 [back to contents](#contents)
 
-Support: <span style="color:pink">Deprecated</span>  
+Support: <span style="color:pink">Deprecated</span>
 Usage: <span style="color:red">Rare</span>
 
 The length argument is deprecated. Few planners will support it (if any).
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL Examples](https://github.com/yarox/pddl-examples)

--- a/docs/reference/PDDL2.2/Domain/requirements.md
+++ b/docs/reference/PDDL2.2/Domain/requirements.md
@@ -1,15 +1,17 @@
 # Requirements (PDDL 2.2)
+
 The following page offers details of requirements defined in PDDL 2.2.
 
 ## Derived Predicates
-Support: <span style="color:orange">Medium</span>  
+
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :derived-predicates)`
 
 Allows the usage of derived predicates in domains. e.g.
 
-```
+```LISP
 (:derived (train-usable ?t - train)
     (and
         (train-has-guard ?t)
@@ -19,7 +21,8 @@ Allows the usage of derived predicates in domains. e.g.
 ```
 
 ## Timed Initial Literals
-Support: <span style="color:orange">Medium</span>  
+
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:yellow">Medium</span>
 
 `(:requirements :timed-initial-literals)`

--- a/docs/reference/PDDL2.2/domain.md
+++ b/docs/reference/PDDL2.2/domain.md
@@ -1,13 +1,14 @@
 # Domain
-[return to homepage](../../readme.md) | [return to PDDL2.2 main page](./main.md) | 
+
+[return to homepage](../../readme.md) | [return to PDDL2.2 main page](./main.md) |
 
 The domain syntax for PDDL2.2 adds very minimal changes to the domain. As with any update to PDDL it introduces new requirements, however, other than that the only new syntax is Derived Predicates, which are defined in a similar way to how actions are defined, and are defined in the same section of the domain file.
 
-```
+```LISP
 (define
     (domain railways)
     (:requirements :derived-predicates :timed-initial-literals)
-    (:types 
+    (:types
         train station - object
     )
     (:predicates
@@ -35,13 +36,15 @@ The domain syntax for PDDL2.2 adds very minimal changes to the domain. As with a
 ```
 
 ## Contents
+
 - Requirements
 - Derived Predicates
 
 ## Requirements
+
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `(:requirements <requirement_name>)`
@@ -53,24 +56,26 @@ Multiple `:requirements` can be specified through a space separated list e.g.
 `(:requirements :strips :adl :typing)`
 
 ### List of Requirements
+
 This is a list of requirements that were added by PDDL2.2 to the language of PDDL.
 
 - [:derived-predicates](./Domain/requirements.md#derived-predicates)
 - [:timed-initial-literals](./Domain/requirements.md#timed-initial-literals)
 
 ## Derived Predicates
+
 [back to contents](#contents)
 
-Support: <span style="color:orange">Medium</span>  
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:derived <predicate_name> <logical_expression>)`
 
-A derived predicate is declared by naming the predicate who's result is being derived, and a logical expression which is evaluated to work out the value. 
+A derived predicate is declared by naming the predicate who's result is being derived, and a logical expression which is evaluated to work out the value.
 
 Note, that a derived predicate is declared similarly to actions, in that we use the `:derived` keyword for each declaration of a derived predicate.
 
-```
+```LISP
 (:derived (train-usable ?t - train)
     (and
         (train-has-guard ?t)
@@ -79,9 +84,10 @@ Note, that a derived predicate is declared similarly to actions, in that we use 
 )
 ```
 
-The example above specifies that a train is only usable if it has a train and a driver. 
+The example above specifies that a train is only usable if it has a train and a driver.
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL2.2: The Language for the Classical Part of the 4th International Planning Competition](https://pdfs.semanticscholar.org/4b3c/0706d2673d817cc7c33e580858e65b134ba2.pdf) [Edelkamp, S. Hoffmann, J.]

--- a/docs/reference/PDDL2.2/main.md
+++ b/docs/reference/PDDL2.2/main.md
@@ -1,7 +1,9 @@
 # PDDL 2.2
+
 [return to homepage](../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 ## Introduction
+
 PDDL 2.2 introduces a key new feature not previously considered in PDDL, Timed Initial Literals. In previous versions, we assumed that a predicate was either true or false at the start.
 
 This is not a realistic way of modelling because it fails to consider facts which may become true later. For example, in dynamic planning, where we are planning and re-planning as the world changes, we may wish to represent resources or states which are in the course of changing which we have no control over.
@@ -21,6 +23,7 @@ PDDL 2.2 also reintroduces Axioms as derived predicates, with a different simple
 *This is speculative.
 
 ## Contents
+
 - [Domain](./domain.md)
     - [Requirements](./domain.md#requirements)
         - [List of PDDL 2.2 Requirements](./domain.md#list-of-requirements)
@@ -29,6 +32,7 @@ PDDL 2.2 also reintroduces Axioms as derived predicates, with a different simple
     - [Timed initial literals](./problem.md#timed-initial-literals)
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL2.2: The Language for the Classical Part of the 4th International Planning Competition](https://pdfs.semanticscholar.org/4b3c/0706d2673d817cc7c33e580858e65b134ba2.pdf) [Edelkamp, S. Hoffmann, J.]

--- a/docs/reference/PDDL2.2/problem.md
+++ b/docs/reference/PDDL2.2/problem.md
@@ -1,11 +1,12 @@
 # Problem
+
 [return to homepage](../../readme.md) | [return to PDDL2.2 main page](./main.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
-The problem syntax in PDDL 2.2 is expanded very lightly in order to support Timed Initial Literals. The choice of keyword is an interesting one because `at` is a commonly used predicate name used to indicate that some locatable is in some location i.e. `(at Adam Bush-House)`. 
+The problem syntax in PDDL 2.2 is expanded very lightly in order to support Timed Initial Literals. The choice of keyword is an interesting one because `at` is a commonly used predicate name used to indicate that some locatable is in some location i.e. `(at Adam Bush-House)`.
 
 The way in which this keyword is used to define timed initial literals means however that it *should not* conflict with domains that make use of `at` as a predicate name. However, this is entirely dependent on how the planner parses a plan.
 
-```
+```LISP
 (define
     (problem trainplanning1)
     (:domain railways)
@@ -23,12 +24,14 @@ The way in which this keyword is used to define timed initial literals means how
 ```
 
 ## Contents
+
 - Timed initial literals
 
 ## Timed Initial Literals
+
 [back to contents](#contents)
 
-Support: <span style="color:orange">Medium</span>  
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:yellow">Medium</span>
 
 `(at <time_value> <predicate>)`
@@ -44,6 +47,7 @@ Ultimately it is the responsibility of the modelling user to determine what scal
 The statement above expresses that at some time 20, the train `train2` will no longer be in use.
 
 ## References
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL2.2: The Language for the Classical Part of the 4th International Planning Competition](https://pdfs.semanticscholar.org/4b3c/0706d2673d817cc7c33e580858e65b134ba2.pdf) [Edelkamp, S. Hoffmann, J.]

--- a/docs/reference/PDDL3.0/Domain/requirements.md
+++ b/docs/reference/PDDL3.0/Domain/requirements.md
@@ -1,10 +1,12 @@
 # Requirements (PDDL 3.0)
+
 [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 The following page offers details of requirements defined in PDDL 3.0.
 
 ## Preferences
-Support: <span style="color:orange">Medium</span>  
+
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:yellow">Medium</span>
 
 `(:requirements :preferences)`
@@ -12,14 +14,15 @@ Usage: <span style="color:yellow">Medium</span>
 Allows for the usage of preferences within problem definitions (soft goals).
 
 ## Constraints
-Support: <span style="color:orange">Medium</span>  
+
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:orange">Low</span>
 
 `(:requirements :constraints)`
 
 Allows for the use of constraints within domain definitions (goals which must be satisfied in every state). e.g.
 
-```
+```LISP
 (:constraints
     (and
         (forall (?l - lorry ?loc - location) (at-most-once (at ?l ?loc)))

--- a/docs/reference/PDDL3.0/domain.md
+++ b/docs/reference/PDDL3.0/domain.md
@@ -1,11 +1,12 @@
 # Domain
+
 [return to homepage](../../readme.md) | [return to PDDL3.0 main page](./main.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
-As with all previous installations of PDDL, PDDL 3.0 introduces new requirements. It also introducing syntax for defining constraints. Constraints are form of goal which must be satisfied in all states of the plan. 
+As with all previous installations of PDDL, PDDL 3.0 introduces new requirements. It also introducing syntax for defining constraints. Constraints are form of goal which must be satisfied in all states of the plan.
 
 As an additional curiosity note, whilst it may seem that a constraint adds more complexity to a state space, in general it allows us to reduce it significantly, by increasing the number of invalid states.
 
-```
+```LISP
 (define
     (domain logistics)
     (:requirements :preferences :constraints)
@@ -29,6 +30,7 @@ As an additional curiosity note, whilst it may seem that a constraint adds more 
 ```
 
 ## Contents
+
 - [Requirements](#requirements)
 - [Constraints](#constraints)
     - [always](#always)
@@ -44,7 +46,7 @@ As an additional curiosity note, whilst it may seem that a constraint adds more 
 ## Requirements
 [back to contents](#contents)
 
-Support: <span style="color:green">Universal</span>  
+Support: <span style="color:green">Universal</span>
 Usage: <span style="color:green">High</span>
 
 `(:requirements <requirement_name>)`
@@ -56,18 +58,20 @@ Multiple `:requirements` can be specified through a space separated list e.g.
 `(:requirements :strips :adl :typing)`
 
 ### List of Requirements
+
 This is a list of requirements that were added by PDDL3.0 to the language of PDDL.
 
 - [:preferences](./Domain/requirements.md#preferences)
 - [:constraints](./Domain/constraints.md#constraints)
 
 ## Constraints
+
 [back to contents](#contents)
 
-Support: <span style="color:orange">Medium</span>  
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:orange">Low</span>
 
-```
+```LISP
 (:constraints
     <logical_expression>
 )
@@ -77,7 +81,7 @@ Constraints are a conjunction of various `forall`/`exists` statements, which can
 
 Essentially a constraint expresses something we want to always be true, or some state-trajectory constraint (A constraint on how the state changes over time) . e.g.
 
-```
+```LISP
 (:constraints
     (and
         (forall (?l - lorry ?loc - location) (at-most-once (at ?l ?loc)))
@@ -86,9 +90,9 @@ Essentially a constraint expresses something we want to always be true, or some 
 )
 ```
 
-The single constraint shown above expresses that for each lorry and location, the lorry should visit that location at most once. 
+The single constraint shown above expresses that for each lorry and location, the lorry should visit that location at most once.
 
-These kind of expressions can help planners reduce the number of states they need to explore by enforcing common sense logic. 
+These kind of expressions can help planners reduce the number of states they need to explore by enforcing common sense logic.
 
 Now it may seem logical that if packages can be delivered in any particular order and there could potentially be more than one package to be delivered to a single location, that we would want to express that we only visit any given location exactly once with a given lorry (thus preventing us going to the same place twice).
 
@@ -98,9 +102,9 @@ Users of this feature should be cautious of not ruling out non-apparent solution
 
 `always <predicate>`
 
-The `always` state-trajectory constraint expresses that every state reached in the execution of the plan, contains the predicate specified. 
+The `always` state-trajectory constraint expresses that every state reached in the execution of the plan, contains the predicate specified.
 
-It essentially creates a constant predicate. In the case below we say that `package1` is in `lorry1` for all states reached by the plan. 
+It essentially creates a constant predicate. In the case below we say that `package1` is in `lorry1` for all states reached by the plan.
 
 `always (in package1 lorry1)`
 
@@ -118,7 +122,7 @@ It essentially says, at some point, this fact is true. In the case below we're s
 
 `within <number> <predicate>`
 
-The `within` state-trajectory constraint express that some predicate must become true within the specified number of plan steps. 
+The `within` state-trajectory constraint express that some predicate must become true within the specified number of plan steps.
 
 This is a rather unusual constraint because it varies between temporal and STRIPS domain. The number in the statement expresses the point in time in temporal plans. The number in the statement expresses the number of plan steps in STRIPS plans.
 
@@ -131,7 +135,9 @@ This is a rather unusual constraint because it varies between temporal and STRIP
 The `at-most-once` state-trajectory constraint expresses that a fact be true at most once. It is useful to prevent repeated visits to the same fact. e.g.
 
 `at-most-once (at lorry1 theendoftheworld)`
+
 ### sometime-after
+
 `sometime-after <before_predicate> <after_predicate>`
 
 The `sometime-after` state-trajectory constraint expresses that some predicate becomes true, at some point after a separate predicate becomes true.
@@ -141,6 +147,7 @@ The `sometime-after` state-trajectory constraint expresses that some predicate b
 The above statement expresses that once `lorry1` has been in london some point afterwards in should be in `pompey`.
 
 ### sometime-before
+
 `sometime-before <after_predicate> <before_predicate>`
 
 The `sometime-before` state-trajectory constraint expresses that some predicate should become true, before a separate predicate becomes true. e.g.
@@ -150,18 +157,20 @@ The `sometime-before` state-trajectory constraint expresses that some predicate 
 The above statement expresses that before `lorry1` is marked as delivering it should have been `at` the `warehouse` (i.e. to pickup goods).
 
 ### always-within
+
 `always-within <number> <condition> <predicate>`
 
 The always within expresses a composition of `always` and `within`, essentially it says that whenever some condition/predicate is true, then within the specified number of steps/time, the other predicate should become true.
 
 ### hold-during
+
 `hold-during <number> <number> <predicate>`
 
 The `holding-during` state-trajectory constraint expresses that a predicate should hold true between the two points in time expressed. Essentially, action as an `always` with a fixed start and end point.
 
 `hold-during 20 30 (at lorry1 lorrycarpark)`
 
-The statement above expresses that `lorry1` should be parked between the points in time `20` and `30`. If we imagine that time in our problem represents hours, then `20` would be 8PM on the first day, and `30` would be 6AM on the next day. 
+The statement above expresses that `lorry1` should be parked between the points in time `20` and `30`. If we imagine that time in our problem represents hours, then `20` would be 8PM on the first day, and `30` would be 6AM on the next day.
 
 ### hold-after
 
@@ -176,6 +185,7 @@ Note that this predicate must remain true, forever after the give point. This ma
 The above statement indicates that `lorry1` should be `empty` after `40` and remain empty.
 
 ## Reference
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL2.2: The Language for the Classical Part of the 4th International Planning Competition](https://pdfs.semanticscholar.org/4b3c/0706d2673d817cc7c33e580858e65b134ba2.pdf) [Edelkamp, S. Hoffmann, J.]

--- a/docs/reference/PDDL3.0/main.md
+++ b/docs/reference/PDDL3.0/main.md
@@ -1,4 +1,5 @@
 # PDDL 3.0
+
 [return to homepage](../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 ## Introduction
@@ -13,6 +14,7 @@ PDDL 3.0 also introduced constraints, a form of strong goal, which essentially c
 This allows us to express things such as facts that must become true after another, or facts which must always be true. See the keywords included in the Constraints and Preferences sections below.
 
 ## Contents
+
 - [Domain](./domain.md)
     - [Requirements](./domain.md#requirements)
     - [Constraints](./domain.md#constraints)
@@ -39,6 +41,7 @@ This allows us to express things such as facts that must become true after anoth
     - [Metric](./problem.md#metric)
 
 ## Reference
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL2.2: The Language for the Classical Part of the 4th International Planning Competition](https://pdfs.semanticscholar.org/4b3c/0706d2673d817cc7c33e580858e65b134ba2.pdf) [Edelkamp, S. Hoffmann, J.]

--- a/docs/reference/PDDL3.0/problem.md
+++ b/docs/reference/PDDL3.0/problem.md
@@ -1,9 +1,10 @@
 # Problem
+
 [return to homepage](../../readme.md) | [return to PDDL3.0 main page](./main.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 New syntax is added to PDDL problems in PDDL3. This syntax allows us to express preferences as part of the `:goal` section of a problem file.
 
-```
+```LISP
 (define
     (problem logistics1)
     (:domain logistics)
@@ -26,6 +27,7 @@ New syntax is added to PDDL problems in PDDL3. This syntax allows us to express 
 ```
 
 ## Contents
+
 - [Preferences](#preferences)
     - [always](#always)
     - [sometime](#sometime)
@@ -37,10 +39,12 @@ New syntax is added to PDDL problems in PDDL3. This syntax allows us to express 
     - [hold-during](#hold-during)
     - [hold-after](#hold-after)
 - [Metric](#metric)
+
 ## Preferences
+
 [back to contents](#contents)
 
-Support: <span style="color:orange">Medium</span>  
+Support: <span style="color:orange">Medium</span>
 Usage: <span style="color:yellow">Medium</span>
 
 `preference <name> <goal>`
@@ -49,7 +53,7 @@ A preference is a soft goal, which often uses a state-trajectory constraint to e
 
 The syntax of a preference is defined such that it can be used as part of a conjunctive goal definition, meaning we can define preferences and goals together. An example preference below shows that `lorry1` would ideally visit `london` before it visits `glasgow`
 
-```
+```LISP
 (preference visitLDNthenGLS
     (sometime-after (at lorry1 london) (at lorry1 glasgow))
 )
@@ -59,9 +63,9 @@ The syntax of a preference is defined such that it can be used as part of a conj
 
 `always <predicate>`
 
-The `always` state-trajectory constraint expresses that every state reached in the execution of the plan, contains the predicate specified. 
+The `always` state-trajectory constraint expresses that every state reached in the execution of the plan, contains the predicate specified.
 
-It essentially creates a constant predicate. In the case below we say that `package1` is in `lorry1` for all states reached by the plan. 
+It essentially creates a constant predicate. In the case below we say that `package1` is in `lorry1` for all states reached by the plan.
 
 `always (in package1 lorry1)`
 
@@ -79,7 +83,7 @@ It essentially says, at some point, this fact is true. In the case below we're s
 
 `within <number> <predicate>`
 
-The `within` state-trajectory constraint express that some predicate must become true within the specified number of plan steps. 
+The `within` state-trajectory constraint express that some predicate must become true within the specified number of plan steps.
 
 This is a rather unusual constraint because it varies between temporal and STRIPS domain. The number in the statement expresses the point in time in temporal plans. The number in the statement expresses the number of plan steps in STRIPS plans.
 
@@ -92,7 +96,9 @@ This is a rather unusual constraint because it varies between temporal and STRIP
 The `at-most-once` state-trajectory constraint expresses that a fact be true at most once. It is useful to prevent repeated visits to the same fact. e.g.
 
 `at-most-once (at lorry1 theendoftheworld)`
+
 ### sometime-after
+
 `sometime-after <before_predicate> <after_predicate>`
 
 The `sometime-after` state-trajectory constraint expresses that some predicate becomes true, at some point after a separate predicate becomes true.
@@ -102,6 +108,7 @@ The `sometime-after` state-trajectory constraint expresses that some predicate b
 The above statement expresses that once `lorry1` has been in london some point afterwards in should be in `pompey`.
 
 ### sometime-before
+
 `sometime-before <after_predicate> <before_predicate>`
 
 The `sometime-before` state-trajectory constraint expresses that some predicate should become true, before a separate predicate becomes true. e.g.
@@ -111,18 +118,20 @@ The `sometime-before` state-trajectory constraint expresses that some predicate 
 The above statement expresses that before `lorry1` is marked as delivering it should have been `at` the `warehouse` (i.e. to pickup goods).
 
 ### always-within
+
 `always-within <number> <condition> <predicate>`
 
 The always within expresses a composition of `always` and `within`, essentially it says that whenever some condition/predicate is true, then within the specified number of steps/time, the other predicate should become true.
 
 ### hold-during
+
 `hold-during <number> <number> <predicate>`
 
 The `holding-during` state-trajectory constraint expresses that a predicate should hold true between the two points in time expressed. Essentially, action as an `always` with a fixed start and end point.
 
 `hold-during 20 30 (at lorry1 lorrycarpark)`
 
-The statement above expresses that `lorry1` should be parked between the points in time `20` and `30`. If we imagine that time in our problem represents hours, then `20` would be 8PM on the first day, and `30` would be 6AM on the next day. 
+The statement above expresses that `lorry1` should be parked between the points in time `20` and `30`. If we imagine that time in our problem represents hours, then `20` would be 8PM on the first day, and `30` would be 6AM on the next day.
 
 ### hold-after
 
@@ -137,6 +146,7 @@ Note that this predicate must remain true, forever after the give point. This ma
 The above statement indicates that `lorry1` should be `empty` after `40` and remain empty.
 
 ## Metric
+
 For a full definition of the metric block in PDDl, please see [PDDL 2.1](../PDDL2.1/problem.md#metric)
 
 The metric is a numeric function which must either be minimized or maximised. PDDL3 extends on the definition in PDDL2.1 to include a helper function `is-violated <name>` which when given the name of a preference, gives a count of the number of times that constraint has been violated.
@@ -145,19 +155,21 @@ In some cases, users may wish to weight certain preferences as being more costly
 
 e.g. Imagine we have two preferences, `visitLDNthenGLS` and `lorryEndsAtDepot` we can define a metric something like this
 
-```
+```LISP
 (:metric
-    (+ 
-        (* (is-violated visitLDNthenGLS) 10) 
+    (+
+        (* (is-violated visitLDNthenGLS) 10)
         (* (is-violated lorryEndsAtDepot) 5)
     )
 )
 ```
+
 The metric above essentially costs more not to visit `london` before `glasgow` than for the `lorry` to end at the depot.
 
 Usage notes: a preference can be violated once, or multiple times depending on how it's defined. This is not covered in this reference, for more details see section 3.1 of [Plan Constraints and Preferences in PDDL 3](http://www.cs.yale.edu/homes/dvm/papers/pddl-ipc5.pdf) [Gerevini, A. Long, D.]
 
 ## Reference
+
 - [PDDL - The Planning Domain Definition Language](http://www.cs.cmu.edu/~mmv/planning/readings/98aips-PDDL.pdf), [Ghallab, M. Howe, A. Knoblock, C. McDermott, D. Ram, A. Veloso, M. Weld, D. Wilkins, D.]
 - [PDDL2.1: An Extension to PDDL for Expressing Temporal Planning Domains](https://jair.org/index.php/jair/article/view/10352/24759), [Fox, M. Long, D.]
 - [PDDL2.2: The Language for the Classical Part of the 4th International Planning Competition](https://pdfs.semanticscholar.org/4b3c/0706d2673d817cc7c33e580858e65b134ba2.pdf) [Edelkamp, S. Hoffmann, J.]

--- a/docs/reference/planners/POPF/main.md
+++ b/docs/reference/planners/POPF/main.md
@@ -1,6 +1,6 @@
 # POPF: Partial Order Planning Forwards
-[return to homepage](../../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
+[return to homepage](../../../readme.md) | [Report a problem with this guide](https://github.com/nergmada/pddl-reference/issues/new/choose)
 
 Year Published: 2010
 
@@ -91,7 +91,9 @@ POPF has several versions and this guide provides support tables for versions 1.
 |:time| No
 
 ## Downloading and Compiling POPF
+
 [POPF's main KCL Planning page](https://nms.kcl.ac.uk/planning/software/popf.html) provides more detail about the POPF Planner and where the source code can be found.
 
 ## Additional Notes
+
 POPF only supports linear continuous effects


### PR DESCRIPTION
- few minor fixes
- LISP style selected for code block formatting
- whitespace in markdown adjusted to comply with Markdown Linter rules (for readability)
- question: shouldn't the continuous effects be documented in PDDL2.1 page?